### PR TITLE
feat: nohello.net command

### DIFF
--- a/cogs/utility.py
+++ b/cogs/utility.py
@@ -12,7 +12,10 @@ class Utility(commands.Cog):
     @commands.command()
     async def conventional(self, ctx):
         await ctx.send('https://www.conventionalcommits.org/en/v1.0.0/')
-
+    
+    @commands.command()
+    async def nohello(self, ctx):
+        await ctx.send('https://nohello.net/')
 
 def setup(bot):
     bot.add_cog(Utility(bot))


### PR DESCRIPTION
In normal discussion, we already have g!ask, but no g!nohello if someone just says hello in github discussion/programming discussions - so implemented this.